### PR TITLE
Fix for UPPERCASEWordsInCamelAndPASCALCase

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,12 @@ var acceptString = function (fn) {
  */
 var sanitizeString = function (string, replacement, separator) {
   var index = -1;
-
+  
   return string
+    // Fix UPPERCASE words
+    .replace(/([A-Z]*)([A-Z]{1})/g, function (word, $0, $1) {
+      return e.titleCase($0) + $1;
+    })
     .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
     .replace(/([^a-zA-Z0-9]*)([a-zA-Z0-9]*)/g, function (_, $0, $1) {
       var prefix = $0;
@@ -45,6 +49,7 @@ var sanitizeString = function (string, replacement, separator) {
 
       return prefix + replacement($1, index, string);
     });
+
 };
 
 /**
@@ -60,6 +65,26 @@ var e = exports;
  * @type {Array}
  */
 e.insignificantWords = ['and'];
+
+/**
+ * Returns a boolean describing whether the string is all UPPERCASE or not.
+ * 
+ * @param  {String} string
+ * @return {Boolean}
+ */
+e.isUpperCase = acceptString(function (string) {
+  return string == e.upperCase(string);
+});
+
+/**
+ * Returns a boolean describing whether the string is all lowercase or not.
+ * 
+ * @param  {String} string
+ * @return {Boolean}
+ */
+e.isLowerCase = acceptString(function (string) {
+  return string == e.lowerCase(string);
+});
 
 /**
  * Lowercase a passed in string.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "change-case",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Convert strings between camelCase, PascalCase, Title Case, snake_case, etc",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -19,6 +19,18 @@ describe('change case', function () {
     assert.equal(changeCase.upperCaseFirst('test'), 'Test');
   });
 
+  it('should determine whether a string is all upper case or not', function () {
+    assert.equal(changeCase.isUpperCase('ALLUPPERCASE'), true);
+    assert.equal(changeCase.isUpperCase('NotAllUpperCase'), false);
+    assert.equal(changeCase.isUpperCase('alllowercase'), false);
+  });
+
+  it('should determine whether a string is all upper case or not', function () {
+    assert.equal(changeCase.isLowerCase('ALLUPPERCASE'), false);
+    assert.equal(changeCase.isLowerCase('NotAllLowerCase'), false);
+    assert.equal(changeCase.isLowerCase('alllowercase'), true);
+  });
+
   it('should convert to title case', function () {
     assert.equal(changeCase.titleCase('a test sentence'), 'A Test Sentence');
     assert.equal(changeCase.titleCase('s.p.e.c'), 'S.P.E.C');
@@ -38,20 +50,24 @@ describe('change case', function () {
   });
 
   it('should convert to camel case', function () {
+
     assert.equal(changeCase.camelCase('TestString'),  'testString');
     assert.equal(changeCase.camelCase('Test String'), 'testString');
     assert.equal(changeCase.camelCase('Test_String'), 'testString');
     assert.equal(changeCase.camelCase('Test-String'), 'testString');
+    assert.equal(changeCase.camelCase('TESTString'),  'testString');
     assert.equal(changeCase.camelCase('-webkit-transform'), 'webkitTransform');
     assert.equal(changeCase.camelCase('fooBarBaz'), 'fooBarBaz');
     assert.equal(changeCase.camelCase('some (things)'), 'someThings');
   });
 
   it('should convert to pascal case', function () {
+
     assert.equal(changeCase.pascalCase('testString'),  'TestString');
     assert.equal(changeCase.pascalCase('Test String'), 'TestString');
     assert.equal(changeCase.pascalCase('Test_String'), 'TestString');
     assert.equal(changeCase.pascalCase('Test-String'), 'TestString');
+    assert.equal(changeCase.pascalCase('TESTString'),  'TestString');
     assert.equal(changeCase.pascalCase('a-test-again'), 'ATestAgain');
     assert.equal(changeCase.pascalCase('a---better__test'), 'ABetterTest');
   });


### PR DESCRIPTION
Before, changeCase.camel("TESTString") would be converted to "teststring". This adds a fix for capital words in string to be converted to camel and pascal.
