### PR TITLE
Fix paramCase in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Return as a lower case, dash separated string.
 
 ```js
 changeCase.paramCase('test string');
-//=> "test-case"
+//=> "test-string"
 ```
 
 [dotCase](https://github.com/blakeembrey/dot-case) changeCase.dot(string)


### PR DESCRIPTION
Hi,
Here is a little fix.

``` js
var changeCase = require("./change-case")
changeCase.paramCase('test string');
// 'test-string'
```
