### PR TITLE
Update Travis CI badge link to com TLD from org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Change Case
 
-[![Build status](https://img.shields.io/travis/blakeembrey/change-case.svg?style=flat)](https://travis-ci.org/blakeembrey/change-case)
+[![Build status](https://img.shields.io/travis/blakeembrey/change-case.svg?style=flat)](https://travis-ci.com/blakeembrey/change-case)
 
 > Transform a string between `camelCase`, `PascalCase`, `Capital Case`, `snake_case`, `param-case`, `CONSTANT_CASE` and others.
 


### PR DESCRIPTION
travis-ci.org will be shutting down in several weeks, with all accounts migrating to travis-ci.com