### PR TITLE
Update noCase README example with different input

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ headerCase("test string");
 > Transform into a lower cased string with spaces between words.
 
 ```js
-noCase("test string");
+noCase("testString");
 //=> "test string"
 ```
 


### PR DESCRIPTION
The `noCase` example had the same input and output, this changes the input to be different from the output for clarity (similar to `sentenceCase` example)