### PR TITLE
Make npm packages smaller

### DIFF
--- a/packages/is-lower-case/package-lock.json
+++ b/packages/is-lower-case/package-lock.json
@@ -10337,11 +10337,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-    },
     "tslint": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",

--- a/packages/is-lower-case/package.json
+++ b/packages/is-lower-case/package.json
@@ -78,8 +78,5 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-standard": "^9.0.0",
     "typescript": "^4.1.2"
-  },
-  "dependencies": {
-    "tslib": "^2.0.3"
   }
 }

--- a/packages/is-lower-case/tsconfig.json
+++ b/packages/is-lower-case/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "importHelpers": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/is-upper-case/package-lock.json
+++ b/packages/is-upper-case/package-lock.json
@@ -10337,11 +10337,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-    },
     "tslint": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",

--- a/packages/is-upper-case/package.json
+++ b/packages/is-upper-case/package.json
@@ -78,8 +78,5 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-standard": "^9.0.0",
     "typescript": "^4.1.2"
-  },
-  "dependencies": {
-    "tslib": "^2.0.3"
   }
 }

--- a/packages/is-upper-case/tsconfig.json
+++ b/packages/is-upper-case/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "importHelpers": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/lower-case-first/package-lock.json
+++ b/packages/lower-case-first/package-lock.json
@@ -10337,11 +10337,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-    },
     "tslint": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",

--- a/packages/lower-case-first/package.json
+++ b/packages/lower-case-first/package.json
@@ -78,8 +78,5 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-standard": "^9.0.0",
     "typescript": "^4.1.2"
-  },
-  "dependencies": {
-    "tslib": "^2.0.3"
   }
 }

--- a/packages/lower-case-first/tsconfig.json
+++ b/packages/lower-case-first/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "importHelpers": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/lower-case/package-lock.json
+++ b/packages/lower-case/package-lock.json
@@ -10337,11 +10337,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-    },
     "tslint": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",

--- a/packages/lower-case/package.json
+++ b/packages/lower-case/package.json
@@ -79,8 +79,5 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-standard": "^9.0.0",
     "typescript": "^4.1.2"
-  },
-  "dependencies": {
-    "tslib": "^2.0.3"
   }
 }

--- a/packages/lower-case/tsconfig.json
+++ b/packages/lower-case/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "importHelpers": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/no-case/package.json
+++ b/packages/no-case/package.json
@@ -66,8 +66,7 @@
     ]
   },
   "dependencies": {
-    "lower-case": "^2.0.2",
-    "tslib": "^2.0.3"
+    "lower-case": "^2.0.2"
   },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^2.2.1",

--- a/packages/no-case/tsconfig.json
+++ b/packages/no-case/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "importHelpers": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/sponge-case/package-lock.json
+++ b/packages/sponge-case/package-lock.json
@@ -10337,11 +10337,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-    },
     "tslint": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",

--- a/packages/sponge-case/package.json
+++ b/packages/sponge-case/package.json
@@ -71,9 +71,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "tslib": "^2.0.3"
-  },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^2.2.1",
     "@types/jest": "^24.0.23",

--- a/packages/sponge-case/tsconfig.json
+++ b/packages/sponge-case/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "importHelpers": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/swap-case/package-lock.json
+++ b/packages/swap-case/package-lock.json
@@ -10337,11 +10337,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-    },
     "tslint": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",

--- a/packages/swap-case/package.json
+++ b/packages/swap-case/package.json
@@ -80,8 +80,5 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-standard": "^9.0.0",
     "typescript": "^4.1.2"
-  },
-  "dependencies": {
-    "tslib": "^2.0.3"
   }
 }

--- a/packages/swap-case/tsconfig.json
+++ b/packages/swap-case/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "importHelpers": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/title-case/package-lock.json
+++ b/packages/title-case/package-lock.json
@@ -10337,11 +10337,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-    },
     "tslint": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",

--- a/packages/title-case/package.json
+++ b/packages/title-case/package.json
@@ -80,8 +80,5 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-standard": "^9.0.0",
     "typescript": "^4.1.2"
-  },
-  "dependencies": {
-    "tslib": "^2.0.3"
   }
 }

--- a/packages/title-case/tsconfig.json
+++ b/packages/title-case/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "importHelpers": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/upper-case-first/package-lock.json
+++ b/packages/upper-case-first/package-lock.json
@@ -10337,11 +10337,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-    },
     "tslint": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",

--- a/packages/upper-case-first/package.json
+++ b/packages/upper-case-first/package.json
@@ -79,8 +79,5 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-standard": "^9.0.0",
     "typescript": "^4.1.2"
-  },
-  "dependencies": {
-    "tslib": "^2.0.3"
   }
 }

--- a/packages/upper-case-first/tsconfig.json
+++ b/packages/upper-case-first/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "importHelpers": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/upper-case/package-lock.json
+++ b/packages/upper-case/package-lock.json
@@ -10337,11 +10337,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-    },
     "tslint": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",

--- a/packages/upper-case/package.json
+++ b/packages/upper-case/package.json
@@ -79,8 +79,5 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-standard": "^9.0.0",
     "typescript": "^4.1.2"
-  },
-  "dependencies": {
-    "tslib": "^2.0.3"
   }
 }

--- a/packages/upper-case/tsconfig.json
+++ b/packages/upper-case/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "importHelpers": false,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,5 +12,6 @@
     "inlineSources": true,
     "types": ["node", "jest"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Overview
I noticed there's an opportunity to reduce the size of the npm packages quite a bit. This PR does 3 things:

1. Remove dependency on `tslib` for packages that don't use it
2. Don't ship tests in the npm package. 
3. Stop generating SourceMaps. Given the limited transformations Typescript makes and since there's no minification, they're of limited use. Node.js, by default, doesn't use them at all and if a bundler uses them it complicates the built for (IMHO) little value.

These are all independently useful. Let me know if you disagree with any of these and I can back out the change.

## Impact

The impact is quite good. As an example `upper-case-first` now weighs just 3547 bytes on disk, down from 67172 bytes (-94.8%).

The breakdown is as follows:

| Step | Size | %age change* |
| - | - | - |
| `tslib` | -51280B | -73.7% |
| SourceMap | -2827B | -4.2% |
| Tests | -3131B | -4.7% |

*based on the original size of the package

Note this doesn't add up, that's because there are source map for the test files so they're counted in both rows =)

## Further opportunities

The `tslib` requirement could be eliminated from the remaining packages if `Object.assign` would be expected as a Polyfill. As an alternative, there could be a dependency on a smaller ponyfill such as `object-assign`.