### PR TITLE
ADDED Option to separate numbers in snake Case

### DIFF
--- a/packages/camel-case/src/index.spec.ts
+++ b/packages/camel-case/src/index.spec.ts
@@ -11,6 +11,11 @@ const TEST_CASES: [string, string, Options?][] = [
   ["version 1.21.0", "version_1_21_0"],
   ["version 1.2.10", "version1210", { transform: camelCaseTransformMerge }],
   ["TestV2", "testV_2", { separateNumbers: true }],
+  ["1test", "1Test", { separateNumbers: true }],
+  ["Foo12019Bar", "foo_12019Bar", { separateNumbers: true }],
+  ["aNumber2in", "aNumber_2In", { separateNumbers: true }],
+  ["V1Test", "v1Test"],
+  ["V1Test with separateNumbers", "v_1TestWithSeparateNumbers", { separateNumbers: true }],
 ];
 
 describe("camel case", () => {

--- a/packages/camel-case/src/index.spec.ts
+++ b/packages/camel-case/src/index.spec.ts
@@ -10,6 +10,7 @@ const TEST_CASES: [string, string, Options?][] = [
   ["version 1.2.10", "version_1_2_10"],
   ["version 1.21.0", "version_1_21_0"],
   ["version 1.2.10", "version1210", { transform: camelCaseTransformMerge }],
+  ["TestV2", "testV_2", { separateNumbers: true }],
 ];
 
 describe("camel case", () => {

--- a/packages/dot-case/src/index.spec.ts
+++ b/packages/dot-case/src/index.spec.ts
@@ -11,6 +11,11 @@ const TEST_CASES: [string, string, Options?][] = [
   ["version 1.2.10", "version.1.2.10"],
   ["version 1.21.0", "version.1.21.0"],
   ["TestV2", "test.v.2", { separateNumbers: true }],
+  ["1test", "1.test", { separateNumbers: true }],
+  ["Foo12019Bar", "foo.12019.bar", { separateNumbers: true }],
+  ["aNumber2in", "a.number.2.in", { separateNumbers: true }],
+  ["V1Test", "v1.test"],
+  ["V1Test with separateNumbers", "v.1.test.with.separate.numbers", { separateNumbers: true }],
 ];
 
 describe("dot case", () => {

--- a/packages/dot-case/src/index.spec.ts
+++ b/packages/dot-case/src/index.spec.ts
@@ -1,6 +1,6 @@
-import { dotCase } from ".";
+import { dotCase, Options } from ".";
 
-const TEST_CASES: [string, string][] = [
+const TEST_CASES: [string, string, Options?][] = [
   ["", ""],
   ["test", "test"],
   ["test string", "test.string"],
@@ -10,12 +10,13 @@ const TEST_CASES: [string, string][] = [
   ["TestV2", "test.v2"],
   ["version 1.2.10", "version.1.2.10"],
   ["version 1.21.0", "version.1.21.0"],
+  ["TestV2", "test.v.2", { separateNumbers: true }],
 ];
 
 describe("dot case", () => {
-  for (const [input, result] of TEST_CASES) {
+  for (const [input, result, options] of TEST_CASES) {
     it(`${input} -> ${result}`, () => {
-      expect(dotCase(input)).toEqual(result);
+      expect(dotCase(input, options)).toEqual(result);
     });
   }
 });

--- a/packages/no-case/src/index.spec.ts
+++ b/packages/no-case/src/index.spec.ts
@@ -53,6 +53,9 @@ const TEST_CASES: [string, string, Options?][] = [
   // Customization.
   ["camel2019", "camel 2019", { splitRegexp: /([a-z])([A-Z0-9])/g }],
   ["minifyURLs", "minify urls", { splitRegexp: /([a-z])([A-Z0-9])/g }],
+
+  // Separate Numbers.
+  ["testString123", "test string 123", { separateNumbers: true }],
 ];
 
 describe("no case", () => {

--- a/packages/no-case/src/index.spec.ts
+++ b/packages/no-case/src/index.spec.ts
@@ -56,6 +56,11 @@ const TEST_CASES: [string, string, Options?][] = [
 
   // Separate Numbers.
   ["testString123", "test string 123", { separateNumbers: true }],
+  ["1test", "1 test", { separateNumbers: true }],
+  ["Foo12019Bar", "foo 12019 bar", { separateNumbers: true }],
+  ["aNumber2in", "a number 2 in", { separateNumbers: true }],
+  ["V1Test", "v1 test"],
+  ["V1Test with separateNumbers", "v 1 test with separate numbers", { separateNumbers: true }],
 ];
 
 describe("no case", () => {

--- a/packages/no-case/src/index.ts
+++ b/packages/no-case/src/index.ts
@@ -5,10 +5,12 @@ export interface Options {
   stripRegexp?: RegExp | RegExp[];
   delimiter?: string;
   transform?: (part: string, index: number, parts: string[]) => string;
+  separateNumbers?: boolean;
 }
 
 // Support camel case ("camelCase" -> "camel Case" and "CAMELCase" -> "CAMEL Case").
 const DEFAULT_SPLIT_REGEXP = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g];
+const SEPARATE_NUMBERS_SPLIT_REGEXP = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g, /([(0-9)])([A-Za-z])/g, /([A-Za-z])([0-9])/g,];
 
 // Remove all non-word characters.
 const DEFAULT_STRIP_REGEXP = /[^A-Z0-9]+/gi;
@@ -17,12 +19,16 @@ const DEFAULT_STRIP_REGEXP = /[^A-Z0-9]+/gi;
  * Normalize the string into something other libraries can manipulate easier.
  */
 export function noCase(input: string, options: Options = {}) {
-  const {
-    splitRegexp = DEFAULT_SPLIT_REGEXP,
+  let {
+    splitRegexp,
     stripRegexp = DEFAULT_STRIP_REGEXP,
     transform = lowerCase,
     delimiter = " ",
+    separateNumbers,
   } = options;
+  if (!splitRegexp) {
+    splitRegexp = separateNumbers ? SEPARATE_NUMBERS_SPLIT_REGEXP : DEFAULT_SPLIT_REGEXP;
+  }
 
   let result = replace(
     replace(input, splitRegexp, "$1\0$2"),

--- a/packages/no-case/src/index.ts
+++ b/packages/no-case/src/index.ts
@@ -10,7 +10,9 @@ export interface Options {
 
 // Support camel case ("camelCase" -> "camel Case" and "CAMELCase" -> "CAMEL Case").
 const DEFAULT_SPLIT_REGEXP = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g];
-const SEPARATE_NUMBERS_SPLIT_REGEXP = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g, /([0-9])([A-Za-z])/g, /([A-Za-z])([0-9])/g,];
+
+// Regex to split numbers ("13test" -> "13 test")
+const SEPARATE_NUMBERS_SPLIT_REGEXP = [...DEFAULT_SPLIT_REGEXP, /([0-9])([A-Za-z])/g, /([A-Za-z])([0-9])/g];
 
 // Remove all non-word characters.
 const DEFAULT_STRIP_REGEXP = /[^A-Z0-9]+/gi;
@@ -19,13 +21,18 @@ const DEFAULT_STRIP_REGEXP = /[^A-Z0-9]+/gi;
  * Normalize the string into something other libraries can manipulate easier.
  */
 export function noCase(input: string, options: Options = {}) {
-  let {
-    splitRegexp,
+  const {
     stripRegexp = DEFAULT_STRIP_REGEXP,
     transform = lowerCase,
     delimiter = " ",
     separateNumbers,
   } = options;
+  let { splitRegexp } = options;
+
+  /**
+   * If splitRegexp was not passed in options, and seperateNumbers is true,
+   * update DEFAULT_SPLIT_REGEXP with regex to split numbers.
+   */
   if (!splitRegexp) {
     splitRegexp = separateNumbers ? SEPARATE_NUMBERS_SPLIT_REGEXP : DEFAULT_SPLIT_REGEXP;
   }

--- a/packages/no-case/src/index.ts
+++ b/packages/no-case/src/index.ts
@@ -10,7 +10,7 @@ export interface Options {
 
 // Support camel case ("camelCase" -> "camel Case" and "CAMELCase" -> "CAMEL Case").
 const DEFAULT_SPLIT_REGEXP = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g];
-const SEPARATE_NUMBERS_SPLIT_REGEXP = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g, /([(0-9)])([A-Za-z])/g, /([A-Za-z])([0-9])/g,];
+const SEPARATE_NUMBERS_SPLIT_REGEXP = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g, /([0-9])([A-Za-z])/g, /([A-Za-z])([0-9])/g,];
 
 // Remove all non-word characters.
 const DEFAULT_STRIP_REGEXP = /[^A-Z0-9]+/gi;

--- a/packages/param-case/src/index.spec.ts
+++ b/packages/param-case/src/index.spec.ts
@@ -9,6 +9,11 @@ const TEST_CASES: [string, string, Options?][] = [
   ["version 1.2.10", "version-1-2-10"],
   ["version 1.21.0", "version-1-21-0"],
   ["TestV2", "test-v-2", { separateNumbers: true }],
+  ["1test", "1-test", { separateNumbers: true }],
+  ["Foo12019Bar", "foo-12019-bar", { separateNumbers: true }],
+  ["aNumber2in", "a-number-2-in", { separateNumbers: true }],
+  ["V1Test", "v1-test"],
+  ["V1Test with separateNumbers", "v-1-test-with-separate-numbers", { separateNumbers: true }],
 ];
 
 describe("param case", () => {

--- a/packages/param-case/src/index.spec.ts
+++ b/packages/param-case/src/index.spec.ts
@@ -1,6 +1,6 @@
-import { paramCase } from ".";
+import { Options, paramCase } from ".";
 
-const TEST_CASES: [string, string][] = [
+const TEST_CASES: [string, string, Options?][] = [
   ["", ""],
   ["test", "test"],
   ["test string", "test-string"],
@@ -8,12 +8,13 @@ const TEST_CASES: [string, string][] = [
   ["TestV2", "test-v2"],
   ["version 1.2.10", "version-1-2-10"],
   ["version 1.21.0", "version-1-21-0"],
+  ["TestV2", "test-v-2", { separateNumbers: true }],
 ];
 
 describe("param case", () => {
-  for (const [input, result] of TEST_CASES) {
+  for (const [input, result, options] of TEST_CASES) {
     it(`${input} -> ${result}`, () => {
-      expect(paramCase(input)).toEqual(result);
+      expect(paramCase(input, options)).toEqual(result);
     });
   }
 });

--- a/packages/pascal-case/src/index.spec.ts
+++ b/packages/pascal-case/src/index.spec.ts
@@ -10,6 +10,11 @@ const TEST_CASES: [string, string, Options?][] = [
   ["version 1.21.0", "Version_1_21_0"],
   ["version 1.21.0", "Version1210", { transform: pascalCaseTransformMerge }],
   ["TestV2", "TestV_2", { separateNumbers: true }],
+  ["1test", "1Test", { separateNumbers: true }],
+  ["Foo12019Bar", "Foo_12019Bar", { separateNumbers: true }],
+  ["aNumber2in", "ANumber_2In", { separateNumbers: true }],
+  ["V1Test", "V1Test"],
+  ["V1Test with separateNumbers", "V_1TestWithSeparateNumbers", { separateNumbers: true }],
 ];
 
 describe("pascal case", () => {

--- a/packages/pascal-case/src/index.spec.ts
+++ b/packages/pascal-case/src/index.spec.ts
@@ -9,6 +9,7 @@ const TEST_CASES: [string, string, Options?][] = [
   ["version 1.2.10", "Version_1_2_10"],
   ["version 1.21.0", "Version_1_21_0"],
   ["version 1.21.0", "Version1210", { transform: pascalCaseTransformMerge }],
+  ["TestV2", "TestV_2", { separateNumbers: true }],
 ];
 
 describe("pascal case", () => {

--- a/packages/snake-case/src/index.spec.ts
+++ b/packages/snake-case/src/index.spec.ts
@@ -1,6 +1,6 @@
-import { snakeCase } from ".";
+import { snakeCase, Options } from ".";
 
-const TEST_CASES: [string, string][] = [
+const TEST_CASES: [string, string, Options?][] = [
   ["", ""],
   ["_id", "id"],
   ["test", "test"],
@@ -9,12 +9,15 @@ const TEST_CASES: [string, string][] = [
   ["TestV2", "test_v2"],
   ["version 1.2.10", "version_1_2_10"],
   ["version 1.21.0", "version_1_21_0"],
+  ["TestV2", "test_v_2", { separateNumbers: true }],
+  ["address line 1", "address_line_1", { separateNumbers: true }],
+  ["Test string For 3rd Test", "test_string_for_3_rd_test", { separateNumbers: true }],
 ];
 
 describe("snake case", () => {
-  for (const [input, result] of TEST_CASES) {
+  for (const [input, result, options] of TEST_CASES) {
     it(`${input} -> ${result}`, () => {
-      expect(snakeCase(input)).toEqual(result);
+      expect(snakeCase(input, options)).toEqual(result);
     });
   }
 });

--- a/packages/snake-case/src/index.spec.ts
+++ b/packages/snake-case/src/index.spec.ts
@@ -12,6 +12,11 @@ const TEST_CASES: [string, string, Options?][] = [
   ["TestV2", "test_v_2", { separateNumbers: true }],
   ["address line 1", "address_line_1", { separateNumbers: true }],
   ["Test string For 3rd Test", "test_string_for_3_rd_test", { separateNumbers: true }],
+  ["1test", "1_test", { separateNumbers: true }],
+  ["Foo12019Bar", "foo_12019_bar", { separateNumbers: true }],
+  ["aNumber2in", "a_number_2_in", { separateNumbers: true }],
+  ["V1Test", "v1_test"],
+  ["V1Test with separateNumbers", "v_1_test_with_separate_numbers", { separateNumbers: true }],
 ];
 
 describe("snake case", () => {

--- a/packages/snake-case/src/index.ts
+++ b/packages/snake-case/src/index.ts
@@ -1,10 +1,35 @@
-import { dotCase, Options } from "dot-case";
+import { dotCase, Options as DotCaseOptions } from "dot-case";
+
+type Options = DotCaseOptions & {
+  separateNumbers?: boolean;
+};
 
 export { Options };
 
-export function snakeCase(input: string, options: Options = {}) {
+function snakeCaseTransform(input: string, options: DotCaseOptions = {}) {
   return dotCase(input, {
     delimiter: "_",
     ...options,
   });
+}
+
+function snakeCaseTransformSplitNumbers(input: string, options: DotCaseOptions = {}) {
+  return dotCase(input, {
+    delimiter: "_",
+    splitRegexp: [
+      /([a-z0-9])([A-Z])/g,
+      /([A-Z])([A-Z][a-z])/g,
+      /([(0-9)])([A-Za-z])/g,
+      /([A-Za-z])([0-9])/g,
+    ],
+    ...options,
+  })
+}
+
+export function snakeCase(input: string, options: Options = {}) {
+  const { separateNumbers, ...rest } = options;
+  if (separateNumbers) {
+    return snakeCaseTransformSplitNumbers(input, rest);
+  }
+  return snakeCaseTransform(input, options);
 }

--- a/packages/snake-case/src/index.ts
+++ b/packages/snake-case/src/index.ts
@@ -1,35 +1,10 @@
-import { dotCase, Options as DotCaseOptions } from "dot-case";
-
-type Options = DotCaseOptions & {
-  separateNumbers?: boolean;
-};
+import { dotCase, Options } from "dot-case";
 
 export { Options };
 
-function snakeCaseTransform(input: string, options: DotCaseOptions = {}) {
+export function snakeCase(input: string, options: Options = {}) {
   return dotCase(input, {
     delimiter: "_",
     ...options,
   });
-}
-
-function snakeCaseTransformSplitNumbers(input: string, options: DotCaseOptions = {}) {
-  return dotCase(input, {
-    delimiter: "_",
-    splitRegexp: [
-      /([a-z0-9])([A-Z])/g,
-      /([A-Z])([A-Z][a-z])/g,
-      /([(0-9)])([A-Za-z])/g,
-      /([A-Za-z])([0-9])/g,
-    ],
-    ...options,
-  })
-}
-
-export function snakeCase(input: string, options: Options = {}) {
-  const { separateNumbers, ...rest } = options;
-  if (separateNumbers) {
-    return snakeCaseTransformSplitNumbers(input, rest);
-  }
-  return snakeCaseTransform(input, options);
 }


### PR DESCRIPTION
This PR adds an option to separate numbers when using snake case, resolves #50 

Eg:

Earlier, `snakeCase('AddressLine1')` would give `'address_line1'`.

With new option, `snakeCase('AddressLine1', { separateNumbers: true })` would return `'address_line_1'`