### PR TITLE
Use no-case directly if dot-case is not needed

### DIFF
--- a/packages/param-case/package-lock.json
+++ b/packages/param-case/package-lock.json
@@ -3294,15 +3294,6 @@
         "domelementtype": "1"
       }
     },
-    "dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",

--- a/packages/param-case/package.json
+++ b/packages/param-case/package.json
@@ -72,7 +72,7 @@
     "access": "public"
   },
   "dependencies": {
-    "dot-case": "^3.0.4",
+    "no-case": "^3.0.4",
     "tslib": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/param-case/src/index.ts
+++ b/packages/param-case/src/index.ts
@@ -1,9 +1,9 @@
-import { dotCase, Options } from "dot-case";
+import { noCase, Options } from "no-case";
 
 export { Options };
 
 export function paramCase(input: string, options: Options = {}) {
-  return dotCase(input, {
+  return noCase(input, {
     delimiter: "-",
     ...options,
   });

--- a/packages/path-case/package-lock.json
+++ b/packages/path-case/package-lock.json
@@ -3294,15 +3294,6 @@
         "domelementtype": "1"
       }
     },
-    "dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",

--- a/packages/path-case/package.json
+++ b/packages/path-case/package.json
@@ -69,7 +69,7 @@
     "access": "public"
   },
   "dependencies": {
-    "dot-case": "^3.0.4",
+    "no-case": "^3.0.4",
     "tslib": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/path-case/src/index.ts
+++ b/packages/path-case/src/index.ts
@@ -1,9 +1,9 @@
-import { dotCase, Options } from "dot-case";
+import { noCase, Options } from "no-case";
 
 export { Options };
 
 export function pathCase(input: string, options: Options = {}) {
-  return dotCase(input, {
+  return noCase(input, {
     delimiter: "/",
     ...options,
   });

--- a/packages/snake-case/package-lock.json
+++ b/packages/snake-case/package-lock.json
@@ -3294,15 +3294,6 @@
         "domelementtype": "1"
       }
     },
-    "dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",

--- a/packages/snake-case/package.json
+++ b/packages/snake-case/package.json
@@ -71,7 +71,7 @@
     "access": "public"
   },
   "dependencies": {
-    "dot-case": "^3.0.4",
+    "no-case": "^3.0.4",
     "tslib": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/snake-case/src/index.ts
+++ b/packages/snake-case/src/index.ts
@@ -1,9 +1,9 @@
-import { dotCase, Options } from "dot-case";
+import { noCase, Options } from "no-case";
 
 export { Options };
 
 export function snakeCase(input: string, options: Options = {}) {
-  return dotCase(input, {
+  return noCase(input, {
     delimiter: "_",
     ...options,
   });


### PR DESCRIPTION
Removes the unneeded intermediate dependency to dot-case which in theses cases only forwarded everything to no-case.

Closes #226 