### PR TITLE
Support unicode regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,17 @@ const options = {
 };
 ```
 
+To support non-ASCII characters, you can use the "letter" character category matcher `\p{L}` together with `/u` Unicode support flag.
+For lowercase `\p{Ll}`, uppercase `\p{Lu}`.
+
+Above regex modified:
+
+```js
+splitRegexp: /([\p{Ll})([\p{Lu}\d])/gu,
+```
+
+See https://www.regular-expressions.info/unicode.html (Unicode Categories section) for more.
+
 ## Related
 
 - [Meteor](https://github.com/Konecty/change-case)

--- a/packages/no-case/src/index.spec.ts
+++ b/packages/no-case/src/index.spec.ts
@@ -42,7 +42,6 @@ const TEST_CASES: [string, string, Options?][] = [
   ["snake_case", "snake case"],
   ["snake_case123", "snake case123"],
   ["snake_case_123", "snake case 123"],
-  ["snake_case_123", "snake case 123"],
   ["čūska_case_123", "čūska case 123"],
 
   // Punctuation.

--- a/packages/no-case/src/index.spec.ts
+++ b/packages/no-case/src/index.spec.ts
@@ -16,6 +16,17 @@ const TEST_CASES: [string, string, Options?][] = [
   ["foo bar123", "foo bar123"],
   ["a1bStar", "a1b star"],
 
+  // unicode name (Latin-1 Supplement)
+  ["SørenKierkegaard", "søren kierkegaard"],
+  // sample of Latin Extended-A
+  ["Ā ā Ă ă Ą ą Ć", "ā ā ă ă ą ą ć"],
+  // sample of Latin Extended Additional
+  ["Ḁ ḁ Ḃ ḃ Ḅ ḅ Ḇ", "ḁ ḁ ḃ ḃ ḅ ḅ ḇ"],
+
+  // strip non letters (letter-like symbols and currency symbols)
+  ["™©®", ""],
+  ["£$", ""],
+
   // Constant case.
   ["CONSTANT_CASE ", "constant case"],
   ["CONST123_FOO", "const123 foo"],
@@ -31,6 +42,8 @@ const TEST_CASES: [string, string, Options?][] = [
   ["snake_case", "snake case"],
   ["snake_case123", "snake case123"],
   ["snake_case_123", "snake case 123"],
+  ["snake_case_123", "snake case 123"],
+  ["čūska_case_123", "čūska case 123"],
 
   // Punctuation.
   ['"quotes"', "quotes"],

--- a/packages/no-case/src/index.ts
+++ b/packages/no-case/src/index.ts
@@ -8,10 +8,13 @@ export interface Options {
 }
 
 // Support camel case ("camelCase" -> "camel Case" and "CAMELCase" -> "CAMEL Case").
-const DEFAULT_SPLIT_REGEXP = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g];
+const DEFAULT_SPLIT_REGEXP = [
+  /([\p{Ll}\d])(\p{Lu})/gu,
+  /(\p{Lu})([\p{Lu}][\p{Ll}])/gu,
+];
 
 // Remove all non-word characters.
-const DEFAULT_STRIP_REGEXP = /[^A-Z0-9]+/gi;
+const DEFAULT_STRIP_REGEXP = /[^\p{L}\d]+/giu;
 
 /**
  * Normalize the string into something other libraries can manipulate easier.

--- a/packages/title-case/src/index.spec.ts
+++ b/packages/title-case/src/index.spec.ts
@@ -59,6 +59,8 @@ const TEST_CASES: [string, string][] = [
   ],
   ["newcastle upon tyne", "Newcastle upon Tyne"],
   ["newcastle *upon* tyne", "Newcastle *upon* Tyne"],
+
+  ["лев николаевич толстой", "Лев Николаевич Толстой"],
 ];
 
 describe("swap case", () => {

--- a/packages/title-case/src/index.ts
+++ b/packages/title-case/src/index.ts
@@ -1,8 +1,8 @@
 const SMALL_WORDS = /\b(?:an?d?|a[st]|because|but|by|en|for|i[fn]|neither|nor|o[fnr]|only|over|per|so|some|tha[tn]|the|to|up|upon|vs?\.?|versus|via|when|with|without|yet)\b/i;
 const TOKENS = /[^\s:–—-]+|./g;
 const WHITESPACE = /\s/;
-const IS_MANUAL_CASE = /.(?=[A-Z]|\..)/;
-const ALPHANUMERIC_PATTERN = /[A-Za-z0-9\u00C0-\u00FF]/;
+const IS_MANUAL_CASE = /.(?=[\p{Lu}]|\..)/u;
+const ALPHANUMERIC_PATTERN = /[\p{Lu}\p{Ll}\d]/u;
 
 export function titleCase(input: string) {
   let result = "";


### PR DESCRIPTION
Hey,

Raycast app extension Change Case depends on your library but it doesn't support Unicode characters.  
This would fix [#4841](https://github.com/raycast/extensions/issues/4841)

Replaced a-z and A-Z matchers with \p{Ll} and \p{Lu}, respectively. Updated README to mention this syntax and link to regular-expressions.info doc page.