### PR TITLE
Add `module` and `types` to package.json to make it resolvable by TypeScript

### DIFF
--- a/packages/change-case/package.json
+++ b/packages/change-case/package.json
@@ -6,6 +6,8 @@
   "files": [
     "dist/"
   ],
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
for now the package of `change-case` cannot be resolved by typescript with tsconfig `"moduleResolution": "node"` since the lack of `module` and `types` field in `package.json`