### PR TITLE
Fix missing "a" from small words.

### DIFF
--- a/packages/title-case/src/index.ts
+++ b/packages/title-case/src/index.ts
@@ -5,6 +5,7 @@ const ALPHANUMERIC_PATTERN = /[\p{L}\d]+/gu;
 const WORD_SEPARATORS = new Set(["—", "–", "-", "―", "/"]);
 
 const SMALL_WORDS = new Set([
+  "a",
   "an",
   "and",
   "as",


### PR DESCRIPTION
Closes #307.  When the regex was converted to a set, the word `a` was simply missed.