### PR TITLE
feat: update change-case package.json exports settings

### DIFF
--- a/packages/change-case/package.json
+++ b/packages/change-case/package.json
@@ -31,11 +31,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./keys": {
       "types": "./dist/keys.d.ts",
-      "import": "./dist/keys.js"
+      "import": "./dist/keys.js",
+      "default": "./dist/keys.js"
     }
   },
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
In certain historical Node.js versions and community build tools, dependency resolution may encounter issues.

```bash
Module not found: Error: Package path . is not exported from package **/node_modules/change-case (see exports field in **/node_modules/change-case/package.json)
```