### PR TITLE
feat: es2020 -> es2015

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "extends": "@borderless/ts-scripts/configs/tsconfig.json",
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "target": "ES2015"
   }
 }


### PR DESCRIPTION
change-case is currently compiled to es2020 target (roughly chrome 80+), which contains `??` that some older browser, bundler (like webpack 4) and node versions don't support.

this PR changed build target to es2015 (roughly chrome 51+), which support wider range of platforms. and the output remains clean without introducing many legacy stuff.