### PR TITLE
Fix change-case/keys types

### DIFF
--- a/packages/change-case/src/keys.spec.ts
+++ b/packages/change-case/src/keys.spec.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { camelCase } from "./keys";
+import * as changeCase from "./index.js";
 
-const TEST_CASES: [unknown, number | undefined, unknown][] = [
+type TestCase = [
+  unknown,
+  number | undefined,
+  unknown,
+  (changeCase.Options | changeCase.PascalCaseOptions)?,
+];
+
+const TEST_CASES: TestCase[] = [
   [
     {
       first_name: "bob",

--- a/packages/change-case/src/keys.ts
+++ b/packages/change-case/src/keys.ts
@@ -3,13 +3,15 @@ import * as changeCase from "./index.js";
 const isObject = (object: unknown) =>
   object !== null && typeof object === "object";
 
-function changeKeysFactory(
+function changeKeysFactory<
+  Options extends changeCase.Options = changeCase.Options,
+>(
   changeCase: (input: string, options?: changeCase.Options) => string,
-): (object: unknown, depth?: number) => unknown {
+): (object: unknown, depth?: number, options?: Options) => unknown {
   return function changeKeys(
     object: unknown,
     depth = 1,
-    options?: changeCase.Options,
+    options?: Options,
   ): unknown {
     if (depth === 0 || !isObject(object)) return object;
 
@@ -32,14 +34,18 @@ function changeKeysFactory(
   };
 }
 
-export const camelCase = changeKeysFactory(changeCase.camelCase);
+export const camelCase = changeKeysFactory<changeCase.PascalCaseOptions>(
+  changeCase.camelCase,
+);
 export const capitalCase = changeKeysFactory(changeCase.capitalCase);
 export const constantCase = changeKeysFactory(changeCase.constantCase);
 export const dotCase = changeKeysFactory(changeCase.dotCase);
 export const trainCase = changeKeysFactory(changeCase.trainCase);
 export const noCase = changeKeysFactory(changeCase.noCase);
 export const kebabCase = changeKeysFactory(changeCase.kebabCase);
-export const pascalCase = changeKeysFactory(changeCase.pascalCase);
+export const pascalCase = changeKeysFactory<changeCase.PascalCaseOptions>(
+  changeCase.pascalCase,
+);
 export const pathCase = changeKeysFactory(changeCase.pathCase);
 export const sentenceCase = changeKeysFactory(changeCase.sentenceCase);
 export const snakeCase = changeKeysFactory(changeCase.snakeCase);


### PR DESCRIPTION
I fixed the TypeScript for change-case-keys, so it allows to pass options.

Instead of this
```
export declare const camelCase: (object: unknown, depth?: number) => unknown;
export declare const capitalCase: (object: unknown, depth?: number) => unknown;
...
```
it produces now this:
```
export declare const camelCase: (object: unknown, depth?: number, options?: changeCase.PascalCaseOptions | undefined) => unknown;
export declare const capitalCase: (object: unknown, depth?: number, options?: changeCase.Options | undefined) => unknown;
...
```