### PR TITLE
Add 'require' Exports Option in package.json to Support CommonJS Modules in tsconfig

### DIFF
--- a/packages/change-case/package.json
+++ b/packages/change-case/package.json
@@ -29,8 +29,16 @@
   },
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
-    "./keys": "./dist/keys.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./keys": {
+      "import": "./dist/keys.js",
+      "require": "./dist/keys.js",
+      "types": "./dist/keys.d.ts"
+    }
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This pull request adds the 'require' field to the `exports` option in the `package.json` file. This change is intended to solve issues with CommonJS module resolution when using TypeScript with `tsconfig.json` configured to use `"module": "commonjs"`.

- Updated `package.json` to include the `require` field in the `exports` section for both the main entry point and the `./keys` subpath.
