### PR TITLE
Add CommonJS output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ coverage/
 .DS_Store
 npm-debug.log
 dist/
+dist-cjs/
 *.tsbuildinfo

--- a/packages/change-case/package.json
+++ b/packages/change-case/package.json
@@ -32,10 +32,11 @@
     ".": "./dist/index.js",
     "./keys": "./dist/keys.js"
   },
-  "main": "./dist/index.js",
+  "main": "./dist-cjs/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "dist-cjs/"
   ],
   "scripts": {
     "bench": "vitest bench",
@@ -47,5 +48,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "ts-scripts": {
+    "project": [
+      "tsconfig.json",
+      "tsconfig-cjs.json"
+    ]
   }
 }

--- a/packages/change-case/tsconfig-cjs.json
+++ b/packages/change-case/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-cjs",
+    "module": "CommonJS"
+  }
+}

--- a/packages/sponge-case/package.json
+++ b/packages/sponge-case/package.json
@@ -31,10 +31,11 @@
   "exports": {
     ".": "./dist/index.js"
   },
-  "main": "./dist/index.js",
+  "main": "./dist-cjs/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "dist-cjs/"
   ],
   "scripts": {
     "bench": "vitest bench",
@@ -46,5 +47,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "ts-scripts": {
+    "project": [
+      "tsconfig.json",
+      "tsconfig-cjs.json"
+    ]
   }
 }

--- a/packages/sponge-case/tsconfig-cjs.json
+++ b/packages/sponge-case/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-cjs",
+    "module": "CommonJS"
+  }
+}

--- a/packages/swap-case/package.json
+++ b/packages/swap-case/package.json
@@ -29,10 +29,11 @@
   "exports": {
     ".": "./dist/index.js"
   },
-  "main": "./dist/index.js",
+  "main": "./dist-cjs/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "dist-cjs/"
   ],
   "scripts": {
     "bench": "vitest bench",
@@ -44,5 +45,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "ts-scripts": {
+    "project": [
+      "tsconfig.json",
+      "tsconfig-cjs.json"
+    ]
   }
 }

--- a/packages/swap-case/tsconfig-cjs.json
+++ b/packages/swap-case/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-cjs",
+    "module": "CommonJS"
+  }
+}

--- a/packages/title-case/package.json
+++ b/packages/title-case/package.json
@@ -29,10 +29,11 @@
   "exports": {
     ".": "./dist/index.js"
   },
-  "main": "./dist/index.js",
+  "main": "./dist-cjs/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "dist-cjs/"
   ],
   "scripts": {
     "bench": "vitest bench",
@@ -44,5 +45,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "ts-scripts": {
+    "project": [
+      "tsconfig.json",
+      "tsconfig-cjs.json"
+    ]
   }
 }

--- a/packages/title-case/tsconfig-cjs.json
+++ b/packages/title-case/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-cjs",
+    "module": "CommonJS"
+  }
+}


### PR DESCRIPTION
I have several projects which, for various reasons:
- use `change-case`,
- need to use CommonJS,
- and need `change-case` synchronously (ie. `import()` isn't good enough).

So, I've been keeping them back on version 4.1.2, just like [90% of your users](https://www.npmjs.com/package/change-case?activeTab=versions):

<img width="763" alt="Screenshot 2024-08-23 at 11 45 23 PM" src="https://github.com/user-attachments/assets/584f72c4-aa65-49fe-a1ec-4f72cee8f1d0">

It's actually *very* easy to publish a package that supports both ESM and CJS nowadays; a lot has changed since [sindresorhus swapped all their packages to ESM](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) (largely thanks to all the difficulties that caused...)

To publish both ESM and CJS, you output with TypeScript twice, then set the package.json's `main` field to a CommonJS file, and the `exports` field to ESM file(s). That's it.

This PR adds CommonJS support to all the packages in the change-case monorepo, by:
- Instructing ts-scripts to use an additional tsconfig for the build step, via its [project config key](https://www.npmjs.com/package/@borderless/ts-scripts#configuration)
- Adding a tiny `tsconfig-cjs.json` for each package which extends the normal one, changing only the output module format and the output dir
- Changing the `main` field in each package.json to point to the CommonJS output. The `exports` field remains the same.

Would you please consider accepting this PR? The time for "Pure ESM packages" has passed, and 4.6 million of your users are ready to move out of 2020.


