### PR TITLE
Fix capitalizing words that start with numbers

### DIFF
--- a/packages/title-case/src/index.spec.ts
+++ b/packages/title-case/src/index.spec.ts
@@ -144,6 +144,8 @@ const TEST_CASES: [string, string, Options?][] = [
     'An example. "I.e. test."',
     { sentenceCase: true },
   ],
+  ["friday the 13th", "Friday the 13th"],
+  ["21st century", "21st Century"],
 ];
 
 describe("swap case", () => {

--- a/packages/title-case/src/index.ts
+++ b/packages/title-case/src/index.ts
@@ -1,10 +1,9 @@
 const TOKENS = /(\S+)|(.)/g;
 const IS_SPECIAL_CASE = /[\.#]\p{Alphabetic}/u; // #tag, example.com, etc.
 const IS_MANUAL_CASE = /\p{Ll}(?=[\p{Lu}])/u; // iPhone, iOS, etc.
-const ALPHANUMERIC_PATTERN = /\p{Alphabetic}+/gu;
+const ALPHANUMERIC_PATTERN = /[\p{Alphabetic}\p{Nd}]+/gu;
 const IS_ACRONYM =
   /^(\P{Alphabetic})*(?:\p{Alphabetic}\.){2,}(\P{Alphabetic})*$/u;
-const IS_DIGIT = /\d/u;
 
 export const WORD_SEPARATORS = new Set(["—", "–", "-", "―", "/"]);
 
@@ -154,12 +153,6 @@ export function titleCase(
           if (smallWords.has(word) && wordSeparators.has(nextChar)) {
             continue;
           }
-        }
-
-        // Avoid capitalizing words that start with numbers.
-        // e.g.: 1st, 2nd
-        if (IS_DIGIT.test(token.charAt(wordIndex - 1))) {
-          continue;
         }
 
         value = upperAt(value, wordIndex, locale);

--- a/packages/title-case/src/index.ts
+++ b/packages/title-case/src/index.ts
@@ -4,6 +4,7 @@ const IS_MANUAL_CASE = /\p{Ll}(?=[\p{Lu}])/u; // iPhone, iOS, etc.
 const ALPHANUMERIC_PATTERN = /\p{Alphabetic}+/gu;
 const IS_ACRONYM =
   /^(\P{Alphabetic})*(?:\p{Alphabetic}\.){2,}(\P{Alphabetic})*$/u;
+const IS_DIGIT = /\d/u;
 
 export const WORD_SEPARATORS = new Set(["—", "–", "-", "―", "/"]);
 
@@ -153,6 +154,12 @@ export function titleCase(
           if (smallWords.has(word) && wordSeparators.has(nextChar)) {
             continue;
           }
+        }
+
+        // Avoid capitalizing words that start with numbers.
+        // e.g.: 1st, 2nd
+        if (IS_DIGIT.test(token.charAt(wordIndex - 1))) {
+          continue;
         }
 
         value = upperAt(value, wordIndex, locale);


### PR DESCRIPTION
Fix issue where words that start with numbers have the first non-numeric character capitalized incorrectly. Previously "1st" was being capitalized as "1St".